### PR TITLE
refactor: shifted admin endpoint's to /admin/.. route

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import cookieSession from "cookie-session";
 import userRouter from "./routes/user.routes";
 import ticketRouter from "./routes/ticket.routes";
 import rateLimiter from "./middleware/rateLimiter.middleware";
+import adminRouter from "./routes/admin.routes";
 
 config();
 
@@ -36,6 +37,7 @@ app.use(deserializeUser);
 app.use("/api", authRouter);
 app.use("/api", userRouter);
 app.use("/api", ticketRouter);
+app.use("/api", adminRouter);
 app.use(rateLimiter);
 
 logger.info("Current Environment: " + process.env.NODE_ENV);

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -1,0 +1,109 @@
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import {
+	DeleteUserSchema,
+	PatchMarkUserVerifiedSchema,
+} from "../schemas/admin.schema";
+import { 
+	deleteUserByIdService,
+	findUsersService,
+	updateUserByIdService,
+} from "../services/user.service";
+import logger from "../utils/logger.util";
+
+
+/**
+ * This controller will get all users from database
+ *
+ * @param req request
+ * @param res response
+ *
+ * @author aayushchugh, is-itayush
+ */
+ export const getAllUsersHandler = async (req: Request, res: Response) => {
+	try {
+		const records = await findUsersService();
+
+		return res.status(StatusCodes.OK).json({
+			message: "Users fetched successfully",
+			records,
+		});
+	} catch (err) {
+		logger.error(err);
+
+		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+			error: "Internal Server Error",
+		});
+	}
+};
+
+/**
+ * This controller will delete user from database
+ *
+ * @param req request
+ * @param res response
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+export const deleteUserHandler = async (
+	req: Request<DeleteUserSchema["params"]>,
+	res: Response,
+) => {
+	const { id } = req.params;
+
+	try {
+		const deletedUser = await deleteUserByIdService(id);
+
+		if (!deletedUser) {
+			return res.status(StatusCodes.NOT_FOUND).json({
+				error: "User not found",
+			});
+		}
+
+		return res.status(StatusCodes.OK).json({
+			message: "User deleted successfully",
+		});
+	} catch (err) {
+		logger.error(err);
+
+		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+			error: "Internal Server Error",
+		});
+	}
+};
+
+/**
+ * This controller will mark user as verified.
+ * this can be used by admin to mark any user as verified
+ *
+ * @param req request
+ * @param res response
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+export const patchMarkUserVerifiedHandler = async (
+	req: Request<PatchMarkUserVerifiedSchema["params"]>,
+	res: Response,
+) => {
+	const { id } = req.params;
+
+	try {
+		const verifiedUser = await updateUserByIdService(id, { verified: true });
+
+		if (!verifiedUser) {
+			return res.status(StatusCodes.NOT_FOUND).json({
+				error: "User not found",
+			});
+		}
+
+		return res.status(StatusCodes.OK).json({
+			message: "User verified successfully",
+		});
+	} catch (err) {
+		logger.error(err);
+
+		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+			error: "Internal Server Error",
+		});
+	}
+};

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,113 +1,13 @@
 import { Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
+
+import { PatchUserSchema } from "../schemas/user.schema";
 import {
-	DeleteUserSchema,
-	PatchMarkUserVerifiedSchema,
-	PatchUserSchema,
-} from "../schemas/user.schema";
-import {
-	deleteUserByIdService,
 	findUserByUsernameService,
-	findUsersService,
 	updateUserByIdService,
 } from "../services/user.service";
 import logger from "../utils/logger.util";
 
-/**
- * This controller will get all users from database
- *
- * @param req request
- * @param res response
- *
- * @author aayushchugh
- */
-export const getAllUsersHandler = async (req: Request, res: Response) => {
-	try {
-		const records = await findUsersService();
-
-		return res.status(StatusCodes.OK).json({
-			message: "Users fetched successfully",
-			records,
-		});
-	} catch (err) {
-		logger.error(err);
-
-		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-			error: "Internal Server Error",
-		});
-	}
-};
-
-/**
- * This controller will delete user from database
- *
- * @param req request
- * @param res response
- *
- * @author aayushchugh
- */
-export const deleteUserHandler = async (
-	req: Request<DeleteUserSchema["params"]>,
-	res: Response,
-) => {
-	const { id } = req.params;
-
-	try {
-		const deletedUser = await deleteUserByIdService(id);
-
-		if (!deletedUser) {
-			return res.status(StatusCodes.NOT_FOUND).json({
-				error: "User not found",
-			});
-		}
-
-		return res.status(StatusCodes.OK).json({
-			message: "User deleted successfully",
-		});
-	} catch (err) {
-		logger.error(err);
-
-		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-			error: "Internal Server Error",
-		});
-	}
-};
-
-/**
- * This controller will mark user as verified.
- * this can be used by admin to mark any user as verified
- *
- * @param req request
- * @param res response
- *
- * @author aayushchugh
- */
-export const patchMarkUserVerifiedHandler = async (
-	req: Request<PatchMarkUserVerifiedSchema["params"]>,
-	res: Response,
-) => {
-	const { id } = req.params;
-
-	try {
-		const verifiedUser = await updateUserByIdService(id, { verified: true });
-
-		if (!verifiedUser) {
-			return res.status(StatusCodes.NOT_FOUND).json({
-				error: "User not found",
-			});
-		}
-
-		return res.status(StatusCodes.OK).json({
-			message: "User verified successfully",
-		});
-	} catch (err) {
-		logger.error(err);
-
-		return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-			error: "Internal Server Error",
-		});
-	}
-};
 
 /**
  * This controller will update user's username

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import {
+    getAllUsersHandler,
+	patchMarkUserVerifiedHandler,
+	deleteUserHandler,
+} from "../controllers/admin.controller";
+import requireAdminRole from "../middleware/requireAdminRole.middleware";
+import validateRequest from "../middleware/validateRequest.middleware";
+import {
+	deleteUserSchema,
+	patchMarkUserVerifiedSchema,
+} from "../schemas/admin.schema";
+
+const adminRouter: Router = Router();
+
+// NOTE: all routes defined with `adminRouter` will be pre-fixed with `/api`
+
+/**
+ * This route will get all users
+ * protected for admin
+ * 
+ * @author aayushchugh, is-it-ayush
+ */
+ adminRouter.get("/admin/users", requireAdminRole, getAllUsersHandler);
+ 
+ 
+/** 
+ * This route will mark user as verified.
+ * protected for admin
+ * 
+ * @author aayushchugh, is-it-ayush
+*/
+ adminRouter.patch("/admin/users/markverified/:id", requireAdminRole, validateRequest(patchMarkUserVerifiedSchema), patchMarkUserVerifiedHandler);
+
+/**
+ * This route will delete a user
+ * protected for admin
+ * 
+ * @author aayushchugh, is-it-ayush
+ */
+ adminRouter.route("/admin/users/:id").delete(requireAdminRole, validateRequest(deleteUserSchema), deleteUserHandler);
+
+ export default adminRouter;

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,15 +1,9 @@
 import { Router } from "express";
 import {
-	deleteUserHandler,
-	getAllUsersHandler,
-	patchMarkUserVerifiedHandler,
 	patchUserHandler,
 } from "../controllers/user.controller";
-import requireAdminRole from "../middleware/requireAdminRole.middleware";
 import validateRequest from "../middleware/validateRequest.middleware";
 import {
-	deleteUserSchema,
-	patchMarkUserVerifiedSchema,
 	patchUserSchema,
 } from "../schemas/user.schema";
 
@@ -18,36 +12,14 @@ const userRouter = Router();
 // NOTE: all routes defined with `userRouter` will be pre-fixed with `/api`
 
 /**
- * This route will get all users
- * protected for admin
- *
- * @author aayushchugh
- */
-userRouter.get("/users", requireAdminRole, getAllUsersHandler);
-
-/**
- * This route will mark user as verified
- * protected for admin
- *
- * @author aayushchugh
- */
-userRouter.patch(
-	"/users/markverified/:id",
-	validateRequest(patchMarkUserVerifiedSchema),
-	patchMarkUserVerifiedHandler,
-);
-
-/**
  * This route does following things
- *
  * PATCH -> update user's username
- * DELETE -> delete user from database (protected for admin)
  *
  * @author aayushchugh
  */
+
 userRouter
 	.route("/users/:id")
 	.patch(validateRequest(patchUserSchema), patchUserHandler)
-	.delete(requireAdminRole, validateRequest(deleteUserSchema), deleteUserHandler);
 
 export default userRouter;

--- a/src/schemas/admin.schema.ts
+++ b/src/schemas/admin.schema.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+/**
+ * This schema is used to validate `DELETE /users/:id` request
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+ export const deleteUserSchema = z.object({
+	params: z.object({
+		id: z.string({ required_error: "Id is required" }),
+	}),
+});
+
+/**
+ * This type is generated using `deleteUserSchema` and can be used
+ * as express Request type generic
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+export type DeleteUserSchema = z.infer<typeof deleteUserSchema>;
+
+/**
+ * This schema is used to validate `/users/markverified/:id` request
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+export const patchMarkUserVerifiedSchema = z.object({
+	params: z.object({
+		id: z.string({ required_error: "Id is required" }),
+	}),
+});
+
+/**
+ * This type is generated using `patchMarkUserVerifiedSchema` and can be used
+ * as express Request type generic
+ *
+ * @author aayushchugh, is-it-ayush
+ */
+export type PatchMarkUserVerifiedSchema = z.infer<typeof patchMarkUserVerifiedSchema>;

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -1,44 +1,6 @@
 import { z } from "zod";
 
 /**
- * This schema is used to validate `DELETE /users/:id` request
- *
- * @author aayushchugh
- */
-export const deleteUserSchema = z.object({
-	params: z.object({
-		id: z.string({ required_error: "Id is required" }),
-	}),
-});
-
-/**
- * This type is generated using `deleteUserSchema` and can be used
- * as express Request type generic
- *
- * @author aayushchugh
- */
-export type DeleteUserSchema = z.infer<typeof deleteUserSchema>;
-
-/**
- * This schema is used to validate `/users/markverified/:id` request
- *
- * @author aayushchugh
- */
-export const patchMarkUserVerifiedSchema = z.object({
-	params: z.object({
-		id: z.string({ required_error: "Id is required" }),
-	}),
-});
-
-/**
- * This type is generated using `patchMarkUserVerifiedSchema` and can be used
- * as express Request type generic
- *
- * @author aayushchugh
- */
-export type PatchMarkUserVerifiedSchema = z.infer<typeof patchMarkUserVerifiedSchema>;
-
-/**
  * This schema is used to validate `PATCH /users/:id` request
  *
  * @author aayushchugh


### PR DESCRIPTION
<!-- -------------------------- Required section --------------------------- -->

### Description

Refactored the admin role endpoint's to it's own `/admin` route. Alll the route's in the `/admin` endpoint now require a special `requireAdminRole`  middleware. 
> Note: 6 test's are bound to fail in this commit. I' haven't written test's for `/admin` yet. The test's still correspond to `/users` endpoint from last main branch merge.

### Before: 
 /users (GET) - Get all users.
 /users/markverified/:id (PATCH) - Marks a user verified.
 /users/:id (DELETE) - Delete's a user.

### Now:
 /admin/users (GET) - Get all users.
 /admin/users/markverified/:id (PATCH) - Marks a user verified.
 /admin/users/:id (DELETE) - Delete's a user.

### Checklist:

<!-- pull request can be still created if all tasks are not completed  -->

- [x] This pull request follow our contribution guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (postman and swagger)
- [ ] I have written tests for the code
- [ ] I have updated .env.example file for new .env variables

<!-- -------------------------- Optional section --------------------------- -->

Closes #90