### PR TITLE
feat: accept marketing email option at signup

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -32,7 +32,7 @@ import { generateRandomOTP } from "../utils/otp.util";
  * @author aayushchugh
  */
 export const signupHandler = async (req: Request<{}, {}, SignupSchema["body"]>, res: Response) => {
-	const { password } = req.body;
+	const { password, receiveMarketingEmails, acceptedTermsAndConditions } = req.body;
 	const username = req.body.username.toLowerCase().trim();
 	const email = req.body.email.toLowerCase().trim();
 
@@ -43,6 +43,8 @@ export const signupHandler = async (req: Request<{}, {}, SignupSchema["body"]>, 
 			password,
 			role: "user",
 			verified: false,
+			receiveMarketingEmails,
+			acceptedTermsAndConditions,
 		});
 
 		const token = await signAccessTokenService(createdUser);

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -38,6 +38,12 @@ export class User {
 	@prop()
 	public passwordResetCode: number | null;
 
+	@prop({ required: true })
+	public acceptedTermsAndConditions: boolean;
+
+	@prop({ required: true, default: false })
+	public receiveMarketingEmails: boolean;
+
 	// TODO: add more fields for email services
 
 	/**

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -17,6 +17,17 @@ export const signupSchema = z.object({
 			email: z
 				.string({ required_error: "Email is required" })
 				.email("Please enter a valid email"),
+			receiveMarketingEmails: z.boolean({
+				required_error: "receive marketing emails can be either true of false",
+			}),
+			acceptedTermsAndConditions: z
+				.boolean({
+					required_error: "Please agree to terms and conditions",
+				})
+				.refine((value) => value === true, {
+					path: ["custom"],
+					message: "Please agree to terms and conditions",
+				}),
 			password: z
 				.string({ required_error: "Password is required" })
 				.min(6, "Password must be at least 6 characters"),


### PR DESCRIPTION
closes #114 

### Description

Added new fields while signup
- `receiveMarketingEmails` -> can be either `true` or `false`
- `acceptedTermsAndConditions` -> must be `true`

### Checklist:

<!-- pull request can be still created if all tasks are not completed  -->

-   [x] This pull request follow our contribution guidelines
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation (postman and wiki)
-   [ ] I have written tests for the code
-   [ ] I have updated .env.example file for new .env variables
