### PR TITLE
feat: pagination while fetching emails from gmail

### DIFF
--- a/src/schemas/mail.schema.ts
+++ b/src/schemas/mail.schema.ts
@@ -9,6 +9,10 @@ export const getEmailsFromGmailSchema = z.object({
 	params: z.object({
 		email: z.string({ required_error: "Email is required" }),
 	}),
+	query: z.object({
+		maxResults: z.string().optional(),
+		pageToken: z.string().optional(),
+	}),
 });
 
 /**


### PR DESCRIPTION
<!-- -------------------------- Required section --------------------------- -->

### Description

Added new queries which will help in pagination

- `maxResults`, default as `100`
- `pageToken` default as `" "`

### Checklist:

<!-- pull request can be still created if all tasks are not completed  -->

-   [x] This pull request follow our contribution guidelines
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation (postman and wiki)
-   [ ] I have written tests for the code
-   [ ] I have updated .env.example file for new .env variables

<!-- -------------------------- Optional section --------------------------- -->

### What is current behavior?

Closes #131 

There is no pagination while fetching emails from gmail

### What is new behavior?

[request example](https://www.postman.com/multiemail/workspace/muti-email-rest-api/example/23576569-8ebddb8b-2e23-4a68-a544-a9b39391cd29)